### PR TITLE
fix #6 - Support ECMAScript 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,15 @@ $> bower install eslevels
 
 How to get ```syntax``` is described at [esprima documentation](http://esprima.org/doc/index.html) in details.
 
-```options``` is a dictionary and so far only one option is available:
+```options``` is a dictionary:
 
 * **mode** &mdash; The String control what javascript constructions should be marked. Available values:
   - __"full"__ &mdash; (default)  Mark a whole source code (white spaces, operators, all keywords,...)
-	- __"mini"__ &mdash; Mark only important scope-related constructions (identifiers, function and catch keywords)
+  - __"mini"__ &mdash; Mark only important scope-related constructions (identifiers, function and catch keywords)
+
+* **escopeOpts** &mdash; Options to pass to [escope.analyze](http://estools.github.io/escope/global.html#analyze)
+  - __"sourceType"__ &mdash; the source type of the script. one of 'script' and 'module'
+  - __"ecmaVersion"__ &mdash; which ECMAScript version is considered (5, 6)
 
 You can understand the meaning of **mode** option from the pictures below:
 

--- a/eslevels.js
+++ b/eslevels.js
@@ -304,14 +304,14 @@
 	}
 
 
-	var getScopes = function (ast) {
+	var getScopes = function (ast, opts) {
 		if (typeof ast === "object" && ast.type === "Program") {
 			if (typeof ast.range !== "object" || ast.range.length !== 2) {
 				throw new Error("eslevels: Context only accepts a syntax tree" +
 					"with range information");
 			}
 		}
-		return escope.analyze(ast)
+		return escope.analyze(ast, opts)
 			.scopes;
 	};
 
@@ -335,7 +335,7 @@
 		var opts = options || {};
 		opts.mode = opts.mode || "full";
 		var result = new RegionList();
-		var scopes = getScopes(ast);
+		var scopes = getScopes(ast, opts.escopeOpts);
 		modes[opts.mode](result, ast, scopes);
 		return result.list();
 	};

--- a/test/input/file02.js
+++ b/test/input/file02.js
@@ -1,0 +1,2 @@
+import Clipboard from 'clipboard';
+

--- a/test/levels.js
+++ b/test/levels.js
@@ -10,9 +10,10 @@ var eslevels = require('../');
 describe('levels function', function () {
 	var inputDir = path.join(__dirname, 'input');
 	var file01 = path.join(inputDir, 'file01.js');
-	var source = fs.readFileSync(file01);
+	var file02 = path.join(inputDir, 'file02.js');
 
 	it('should return right list for "full" mode in ' + file01, function () {
+		var source = fs.readFileSync(file01);
 
 		var ast = esprima.parse(source, {
 			range: true
@@ -47,6 +48,9 @@ describe('levels function', function () {
 	});
 
 	it('should return right list for "mini" mode in ' + file01, function () {
+
+		var source = fs.readFileSync(file01);
+
 		var ast = esprima.parse(source, {
 			range: true
 		});
@@ -75,4 +79,23 @@ describe('levels function', function () {
 						[ 2, 251, 260 ]
 					]);
 	});
+
+	it('should parse file with import declarations' + file02, function () {
+		var source = fs.readFileSync(file02);
+
+		var ast = esprima.parse(source, {
+			range: true,
+			sourceType: 'module'
+		});
+		var levels = eslevels.levels(ast, {
+			mode: 'mini',
+			escopeOpts: {
+				sourceType: 'module',
+				ecmaVersion: 6
+			}
+		});
+		expect(levels)
+			.to.eql( [ [ 1, 7, 15 ] ] );
+	});
+
 });


### PR DESCRIPTION
 This PR implements the `escopeOpts` option, so that an ES6 module can be analysed with eslevels.
Included is a simple test.